### PR TITLE
Update link.yml

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -22,7 +22,7 @@ jobs:
         go-version: '1.20'
 
     - name: Build
-      run: go build -o sast-link
+      run: go build -o sast-link-backend
 
     - name: Deploy to Server
       uses: easingthemes/ssh-deploy@main

--- a/api/v1/oauth.go
+++ b/api/v1/oauth.go
@@ -130,7 +130,7 @@ func OauthUserInfo(c *gin.Context) {
 
 	c.JSON(http.StatusOK, result.Success(gin.H{
 		"email":   user.Email,
-		"user_id": user.Uid,
+		"userId": user.Uid,
 	}))
 }
 

--- a/api/v1/user.go
+++ b/api/v1/user.go
@@ -72,7 +72,7 @@ func UserInfo(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, result.Success(gin.H{
 		"email":   user.Email,
-		"user_id": user.Uid,
+		"userId": user.Uid,
 	}))
 }
 


### PR DESCRIPTION
The filename of the -o flag does not match the filename on the server,
which prevents the script from executing correctly.